### PR TITLE
Query monitor

### DIFF
--- a/FrontbackSettings.inc
+++ b/FrontbackSettings.inc
@@ -103,6 +103,24 @@ class FrontbackSettings {
         'frontback_options_main',
         array( 'id' => 'hideAssigneeOptions', 'default' => FALSE )
       );
+
+      add_settings_field(
+        'disableQueryMonitor',
+        'Disable Query Monitor by Default',
+        array( $this, 'boolean_input_callback' ),
+        'frontback-setting-admin',
+        'frontback_options_main',
+        array( 'id' => 'disable_qm', 'default' => FALSE )
+      );
+
+      add_settings_field(
+          'qmAllowed', // ID
+          'Allow Query Monitor for these accounts (comma separated)', // Title
+          array( $this, 'string_input_callback' ), // Callback
+          'frontback-setting-admin', // Page
+          'frontback_options_main', // Section
+          array( 'id' => 'qm_allow_list' )
+      );
   }
   
   /**

--- a/FrontbackSettings.inc
+++ b/FrontbackSettings.inc
@@ -74,7 +74,7 @@ class FrontbackSettings {
         array( $this, 'boolean_input_callback' ),
         'frontback-setting-admin',
         'frontback_options_main',
-        array( 'id' => 'login_required', 'default' => TRUE )
+        array( 'id' => 'login_required', 'default' => FALSE )
       );
 
       add_settings_field(

--- a/frontback.php
+++ b/frontback.php
@@ -31,6 +31,7 @@ function frontback_add_js() {
     'hideButton' => FALSE,
     'hideReporterOptions' => FALSE,
     'hideAssigneeOptions' => FALSE,
+    'disableQueryMonitor' => TRUE,
   );
   foreach ($opts as $k => $v) {
     $opts[$k] = isset($options[$k])? $options[$k] : $v;
@@ -47,3 +48,44 @@ if (is_admin()) {
   require_once(FRONTBACK_ABSPATH . 'FrontbackSettings.inc');
   $frontback_settings_path = new FrontbackSettings();
 }
+
+function frontback_query_monitor_settings(array $user_caps, array $required_caps, array $args, WP_User $user) {
+
+  $options = get_option('frontback_options');
+  do_action('qm/debug', $options);
+
+  if ($options['disable_qm']) {
+    // Remove QM capability from all users
+    $user_caps['view_query_monitor'] = false; 
+  }
+
+  if (isset($options['qm_allow_list'])) {
+    $allowed_accounts = explode(',', $options['qm_allow_list']);
+    $allowed_accounts = array_map(function ($account) {
+      return trim($account);
+    }, $allowed_accounts);
+
+    if (in_array($user->user_login, $allowed_accounts)) {
+      $user_caps['view_query_monitor'] = true; 
+    }
+  }
+
+  // Add QM capability for a single user named `admin`
+  // if ($user->user_login === 'admin') {
+  //     $user_caps['view_query_monitor'] = true;
+  // }
+  
+  // // Add QM capability to a new user role called `developer`
+  // if (in_array('developer', $user->roles)) {
+  //     $user_caps['view_query_monitor'] = true;
+  // }
+  
+  // // Remove QM capability from a single user named `dev_no_qm`
+  // // (even if they have the `developer` role)
+  // if ($user->user_login === 'dev_no_qm') {
+  //     $user_caps['view_query_monitor'] = false;
+  // }
+
+  return $user_caps;
+}
+add_filter('user_has_cap', 'frontback_query_monitor_settings', 15, 4);

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,14 @@ Tested up to: 4.7
 
 Report front end bugs with screenshots directly into your repo's issue tracker.
 
+== Query Monitor Settings ==
+
+FrontBack’s screenshot tool does not work very well if there are a lot of elements in the current page’s DOM. Unfortunately, the extremely useful Query Monitor plugin adds a ton of elements to the bottom of the page for debugging purposes.
+
+To prevent Query Monitor from running when FrontBack is active, check "Disable Query Monitor by Default" in the FrontBack settings.
+
+If you still want to run Query Monitor for specific accounts so that your developers can use it even when FrontBack is enabled, you can add the user logins for any allowed accounts in the "Allow Query Monitor for these acounts" setting. Separate each login with a comma. This setting will also allow you to enable Query Monitor for users that would not normally have access to it, e.g. users with the Editor role, so use the setting responsibly.
+
 == Changelog ==
 
 = 0.1 =


### PR DESCRIPTION
Adds two new settings to FrontBack's settings page:

- Disable Query Monitor by default (turns off QM for all users when FrontBack is enabled)
- Enable Query Monitor for specific accounts (to override "Disable Query Monitor by default" for some users)

To reduce code repetition, I moved the check for whether FrontBack should be loaded into its own function.

Also updated the readme.txt to explain the new settings.